### PR TITLE
V0.4.0

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -161,3 +161,21 @@
         + Verbosity
         + Printing/exporting of JSON file (or Disable)
 
+#### 2119H
+- Updates
+    - Updated main entry point 'main.py' for 'yt-obtain-url' in 'src/ytscripts/yt_obtain_url/'
+        - Bug Fixes
+            + Fixed an encoding issue
+            - Fixed an issue where due to the nature of concurrency, parallelism and multiprocessing, there will be desynchronization in the input data stream and the output data stream
+                + Used the task's system process ID as an anchor point
+        - Dependencies change
+            + Added library 'time'
+        - Feature Change
+            + Added obtaining of process ID for multiprocess tasks (Serial processing via for loop will use the index of the loop instead)
+            + Replaced the usage of Shared Queues to store results of a task from multiprocessing with just returning a list containing `[current-process-id, api-results, file-contents]`
+            + Replaced async (map.async) pool execution with sync (map)
+            + Added encoding to 'export_titles()' to solve an encoding issue when used with Windows
+            + Removed 'sort_keys=True' from json.dump so that the json dumper does not automatically sort on export
+            + Added function 'sort_by_file()' (UNUSED)
+            + Added output title length validation
+

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -179,3 +179,52 @@
             + Added function 'sort_by_file()' (UNUSED)
             + Added output title length validation
 
+#### 2131H
++ Version: v0.4.0
+
+- Version Changes
+    - yt-obtain-url
+        - Bug Fixes
+            + Fixed an encoding issue
+            - Fixed an issue where due to the nature of concurrency, parallelism and multiprocessing, there will be desynchronization in the input data stream and the output data stream
+                + Used the task's system process ID as an anchor point
+        - Dependencies change
+            + Added library 'time'
+        - Feature Change
+            + Added obtaining of process ID for multiprocess tasks (Serial processing via for loop will use the index of the loop instead)
+            + Replaced the usage of Shared Queues to store results of a task from multiprocessing with just returning a list containing `[current-process-id, api-results, file-contents]`
+            + Replaced async (map.async) pool execution with sync (map)
+            + Added encoding to 'export_titles()' to solve an encoding issue when used with Windows
+            + Removed 'sort_keys=True' from json.dump so that the json dumper does not automatically sort on export
+            + Added function 'sort_by_file()' (UNUSED)
+            + Added output title length validation
+
+- Updates
+    - Updated document 'README.md'
+        + Updated version to 'v0.4.0'
+    - Updated python packaging configuration file 'pyproject.toml'
+        + Updated version to 'v0.4.0'
+    - Updated document 'scripts.md' in 'docs/'
+        + Updated version to 'v0.4.0'
+    - Updated main entry point 'main.py' for 'yt-obtain-url' in 'src/ytscripts/yt_obtain_url/'
+        - Bug Fixes
+            + Fixed an encoding issue
+            - Fixed an issue where due to the nature of concurrency, parallelism and multiprocessing, there will be desynchronization in the input data stream and the output data stream
+                + Used the task's system process ID as an anchor point
+        - Dependencies change
+            + Added library 'time'
+        - Feature Change
+            + Added obtaining of process ID for multiprocess tasks (Serial processing via for loop will use the index of the loop instead)
+            + Replaced the usage of Shared Queues to store results of a task from multiprocessing with just returning a list containing `[current-process-id, api-results, file-contents]`
+            + Replaced async (map.async) pool execution with sync (map)
+            + Added encoding to 'export_titles()' to solve an encoding issue when used with Windows
+            + Removed 'sort_keys=True' from json.dump so that the json dumper does not automatically sort on export
+            + Added function 'sort_by_file()' (UNUSED)
+            + Added output title length validation
+
+- TODO
+    + Add CLI argument parsing for optional parameters
+    - Add optional arguments for
+        + Verbosity
+        + Printing/exporting of JSON file (or Disable)
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ YouTube Webscraper CLI utilities and implementations
     + With this being based around Video searches and obtaining information via HTML Parsing
 
 ### Package
-+ Version: v0.3.0
++ Version: v0.4.0
 
 ### Scripts
 + yt-obtain-url : Simple YouTube URL title finder CLI utility

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -4,7 +4,7 @@ List of standalone applications
 ## CLI Applications
 - yt-obtain-url
     - Information
-        + Version: v0.3.0
+        + Version: v0.4.0
     - Script
         - Dependencies
             - Python packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name='yt-scripts'
-version='0.3.0'
+version='0.4.0'
 description="Collection of useful webscraper CLI utilities powered by BeautifulSoup, with this being based around video title searches and obtaining information via HTML Parsing"
 authors = [
     { name="Thanatisia", email="55834101+Thanatisia@users.noreply.github.com" },


### PR DESCRIPTION
### 2024-04-30 2131H
+ Version: v0.4.0

- Version Changes
    - yt-obtain-url
        - Bug Fixes
            + Fixed an encoding issue
            - Fixed an issue where due to the nature of concurrency, parallelism and multiprocessing, there will be desynchronization in the input data stream and the output data stream
                + Used the task's system process ID as an anchor point
        - Dependencies change
            + Added library 'time'
        - Feature Change
            + Added obtaining of process ID for multiprocess tasks (Serial processing via for loop will use the index of the loop instead)
            + Replaced the usage of Shared Queues to store results of a task from multiprocessing with just returning a list containing `[current-process-id, api-results, file-contents]`
            + Replaced async (map.async) pool execution with sync (map)
            + Added encoding to 'export_titles()' to solve an encoding issue when used with Windows
            + Removed 'sort_keys=True' from json.dump so that the json dumper does not automatically sort on export
            + Added function 'sort_by_file()' (UNUSED)
            + Added output title length validation

- Updates
    - Updated document 'README.md'
        + Updated version to 'v0.4.0'
    - Updated python packaging configuration file 'pyproject.toml'
        + Updated version to 'v0.4.0'
    - Updated document 'scripts.md' in 'docs/'
        + Updated version to 'v0.4.0'
    - Updated main entry point 'main.py' for 'yt-obtain-url' in 'src/ytscripts/yt_obtain_url/'
        - Bug Fixes
            + Fixed an encoding issue
            - Fixed an issue where due to the nature of concurrency, parallelism and multiprocessing, there will be desynchronization in the input data stream and the output data stream
                + Used the task's system process ID as an anchor point
        - Dependencies change
            + Added library 'time'
        - Feature Change
            + Added obtaining of process ID for multiprocess tasks (Serial processing via for loop will use the index of the loop instead)
            + Replaced the usage of Shared Queues to store results of a task from multiprocessing with just returning a list containing `[current-process-id, api-results, file-contents]`
            + Replaced async (map.async) pool execution with sync (map)
            + Added encoding to 'export_titles()' to solve an encoding issue when used with Windows
            + Removed 'sort_keys=True' from json.dump so that the json dumper does not automatically sort on export
            + Added function 'sort_by_file()' (UNUSED)
            + Added output title length validation

- TODO
    + Add CLI argument parsing for optional parameters
    - Add optional arguments for
        + Verbosity
        + Printing/exporting of JSON file (or Disable)
